### PR TITLE
Fixed wrong xref words

### DIFF
--- a/docs/modules/ROOT/pages/documentation/payara-server/app-deployment/descriptor-elements.adoc
+++ b/docs/modules/ROOT/pages/documentation/payara-server/app-deployment/descriptor-elements.adoc
@@ -157,7 +157,7 @@ this:
 ----
 
 Enabling the default group to role mappings will cause all named groups
-in the application's xrefed security _realm_ to be mapped to a role of the
+in the application's linked security _realm_ to be mapped to a role of the
 same name. This will save you the time of having to redefine the same
 roles and map them to the realm groups each time they are modified.
 

--- a/docs/modules/ROOT/pages/documentation/payara-server/notification-service/notifiers/xmpp-notifier.adoc
+++ b/docs/modules/ROOT/pages/documentation/payara-server/notification-service/notifiers/xmpp-notifier.adoc
@@ -117,7 +117,7 @@ input the room's *ID*, *Name* and *Description* as requested:
 +
 image:notification-service/xmpp/openfire-create-room-2.png[OpenFire New Room]
 
-. Check that the room was created successfully. Click on the room's xref
+. Check that the room was created successfully. Click on the room's link
 to enter its details. Take special note of the *Service Name*, which
 will be used to configure the notifier later:
 +

--- a/docs/modules/ROOT/pages/documentation/payara-server/server-configuration/http/virtual-servers.adoc
+++ b/docs/modules/ROOT/pages/documentation/payara-server/server-configuration/http/virtual-servers.adoc
@@ -190,7 +190,7 @@ Defines additional properties for the configuration of a virtual server.
   | 300
 | *sso-reap-interval-seconds* | The number of seconds between purges of SSO records. | 60
 | *setCacheControl*           | Comma separated list of Cache-Control response directives (See section 14.9 of: https://www.ietf.org/rfc/rfc2616.txt). | none
-| *allowLinking*             a| If set to true, resources that are symbolic xrefs will be served for all applications deployed to this virtual server. Can be overriden for an individual application in the glassfish-web.xml with:
+| *allowLinking*             a| If set to true, resources that are symbolic links will be served for all applications deployed to this virtual server. Can be overriden for an individual application in the glassfish-web.xml with:
 ----
 <glassfish-web-app>
   <property name="allowLinking" value="false" />

--- a/docs/modules/ROOT/pages/documentation/user-guides/monitoring/monitoring-console.adoc
+++ b/docs/modules/ROOT/pages/documentation/user-guides/monitoring/monitoring-console.adoc
@@ -333,7 +333,7 @@ image::monitoring-console/mc_settings_colors.png[Widget Status Settings]
 === User Defined Watches
 A watch describes the conditions to meet to start and stop alerts in relation to a specific metric.
 For example to get an alert every time an HTTP request causes a server error (responds with any of the 5xx status codes) a custom watch is installed.
-This is very similar to a custom health check that could be xrefed to any metric available where the thresholds are defined as part of the watch.
+This is very similar to a custom health check that could be linked to any metric available where the thresholds are defined as part of the watch.
 There are many varieties of conditions that can be formulated. Each watch has a start condition which when met starts a new alert.
 Optionally a stop condition can be given which when met will stop the alert. If no such stop condition is given an alert stops as soon as its start condition is no longer met.
 Such pairs of start and stop conditions can be defined for 3 levels:
@@ -357,7 +357,7 @@ image::monitoring-console/mc_page_watches2.png[Creating a Watch]
 The above example shows a relatively simple watch named _HTTP server errors_. The name of the watch can be anything as long as it is unique.
 The watch should have both a _Unhealthy_ and a _Degraded_ level.
 
-The field after the _If_ holds the name of the metric series the watch is xrefed to, in this case the `ns:http ServerCount5xx` metric, as shown on the _HTTP_ page. The _in_ clause specifies the unit type of the given metric, here it is the `Count` of 5xx responses. Following _is_ the comparison operator is selected, here `>`. This is followed by the threshold value, here `3` or `1`, and the scope of the comparison, here `in sample`.
+The field after the _If_ holds the name of the metric series the watch is linked to, in this case the `ns:http ServerCount5xx` metric, as shown on the _HTTP_ page. The _in_ clause specifies the unit type of the given metric, here it is the `Count` of 5xx responses. Following _is_ the comparison operator is selected, here `>`. This is followed by the threshold value, here `3` or `1`, and the scope of the comparison, here `in sample`.
 As both do not use a stop condition the checkbox after _until_ is not checked.
 
 The below table describes possible choices for each step of a watch condition.

--- a/docs/modules/ROOT/pages/release-notes/release-notes-151.adoc
+++ b/docs/modules/ROOT/pages/release-notes/release-notes-151.adoc
@@ -46,7 +46,7 @@ This section details the modules that have been upgraded since the last release
 
 This section details the GitHub issues marked as enhancements that have been
 implemented for this release. You can view the issues in detail by following the
-provided xrefs.
+provided links.
 
 * 25 – Disable SSLv3 in default domain template
 * 28 – Integrate Hazelcast as JSR107 provider
@@ -63,7 +63,7 @@ provided xrefs.
 == Fixed Issues
 
 This section details the GitHub issues marked as bugs that have been fixed for
-this release. You can view the issues in detail by following the provided xrefs.
+this release. You can view the issues in detail by following the provided links.
 
 * 45 – GLASSFISH 21148 - fixed bug in SSO clustered session management
 * 46 – GLASSFISH 21219

--- a/docs/modules/ROOT/pages/release-notes/release-notes-153.adoc
+++ b/docs/modules/ROOT/pages/release-notes/release-notes-153.adoc
@@ -78,7 +78,7 @@ This section details the fixes brought in from the GlassFish upstream.
 * https://github.com/payara/Payara/commit/e51a3e5babc8ee05e3ce141cca88ca9ab896fdd7[fix aggregated test report for newer Hudson versions]
 * https://java.net/jira/browse/GLASSFISH-21366[Fix for GLASSFISH-21366]
 * https://github.com/payara/Payara/commit/b5f3237d6aac9c0c22ab45092bf109d71abde6fb[Changed fix for GF 20680326]
-* https://github.com/payara/Payara/commit/ef5cdd175c9af70899d055ebcf150b13c5974b74[fix broken images xrefs, and allow jdk8 to be used to have the {@docRoot}]
+* https://github.com/payara/Payara/commit/ef5cdd175c9af70899d055ebcf150b13c5974b74[fix broken images links, and allow jdk8 to be used to have the {@docRoot}]
 * https://github.com/payara/Payara/commit/a1cbcfddf865b605833ddf59a7f50c30c2716794[FindBug fix]
 * https://java.net/jira/browse/GLASSFISH-20864[fix for bug-20864]
 * https://java.net/jira/browse/GLASSFISH-21261[fix for GLASSFISH-21261]

--- a/docs/modules/ROOT/pages/release-notes/release-notes-173.adoc
+++ b/docs/modules/ROOT/pages/release-notes/release-notes-173.adoc
@@ -98,7 +98,7 @@ EventBus sends same for Instance and ServerName]
 * https://github.com/payara/Payara/pull/1732[PAYARA-1810 - Restart of
 EJB Timers fails when Hazelcast is enabled on a clustered instance.]
 * https://github.com/payara/Payara/pull/1740[PAYARA-1839 - Update the
-documentation xrefs and text in the Admin Console]
+documentation links and text in the Admin Console]
 * https://github.com/payara/Payara/pull/1786[PAYARA-1841 -
 --deployFromGAV won't accept RAR files]
 * https://github.com/payara/Payara/pull/1773[PAYARA-1842 - "Restart


### PR DESCRIPTION
Fixes some xref words where a word **link** in plain text was incorrectly converted to **xref**.

I used this script to replace all occurrences (finds all "xref" strings followed by something else than a colon or those that are at the end of the line and replaces with "link"):

```
find . -type f -name "*.adoc" -print0 | xargs -0 sed -i'' -e 's/xref\([^:]\|$\)/link\1/g'
```