### PR TITLE
Derby DB removed (for 5.201 branch)

### DIFF
--- a/docs/modules/ROOT/pages/documentation/payara-server/h2/h2.adoc
+++ b/docs/modules/ROOT/pages/documentation/payara-server/h2/h2.adoc
@@ -1,9 +1,7 @@
 [[h2-database]]
 = H2 Database
 
-H2 is a Java based Database which will replace Derby as the default database 
-in Payara 5. Derby will be still included with Payara 5 but will no 
-longer be the default database.
+H2 is a Java-based Database which replaced Derby as the default database in Payara 5. Derby as a database service that can be started and managed by Payara Server, has been removed starting from version 5.201
 
 [[why-replace-derby]]
 == Why replace Derby?
@@ -20,13 +18,7 @@ To start the database run the command below:
 asadmin> start-database
 ----
 
-The above command will start H2 on the default port, which is 9092. To explicitly 
-start Derby run the command below:
-
-[source, shell]
-----
-asadmin> start-database --dbtype derby
-----
+The above command will start H2 on the default port, which is 9092. 
 
 [[to-stop-the-database]]
 === To Stop the Database
@@ -37,9 +29,4 @@ To stop the database run the command below:
 asadmin> stop-database
 ----
 
-The above command will stop H2 by default. To explicitly stop Derby run the command below:
-
-[source, shell]
-----
-asadmin> stop-database --dbtype derby
-----
+The above command will stop H2. 


### PR DESCRIPTION
A copy of https://github.com/payara/Payara-Server-Documentation/pull/734 to update the already released 5.201 docs.