### PR TITLE
Support OpenJDK-based JVMs

### DIFF
--- a/docs/modules/ROOT/pages/general-info/supported-platforms.adoc
+++ b/docs/modules/ROOT/pages/general-info/supported-platforms.adoc
@@ -11,6 +11,7 @@ The Payara Platform currently supports the following Java Virtual Machines:
 * Oracle JDK8 (u162+), Oracle JDK 11 (11.0.5+)
 * Azul Zulu JDK8 (u162+), Azul Zulu JDK 11 (11.0.5u10+)
 * OpenJDK JDK8 (u162+), OpenJDK 11 (11.0.5+)
+* All other JVMs based on OpenJDK 8u162+ or 11.0.5+ (for example Corretto JDK, Liberica JDK, AdoptOpenJDK)
 
 TLS 1.3 is supported on JDK 8 with Azul Zulu 1.8.222+ only and all JDK 11 versions.
 


### PR DESCRIPTION
To clarify that we support all OpenJDK-based JVMs