### PR TITLE
Update h2.adoc

### DIFF
--- a/docs/modules/ROOT/pages/documentation/payara-server/h2/h2.adoc
+++ b/docs/modules/ROOT/pages/documentation/payara-server/h2/h2.adoc
@@ -30,3 +30,11 @@ asadmin> stop-database
 ----
 
 The above command will stop H2. 
+
+To connect to the H2 DB Timer database and execute SQL scripts, you should:
+- Stop Payara Server if running
+- Navigate to /path/to/payara/payara5/h2db/bin, to find the h2db binaries
+- Execute java -jar h2.jar (this will start the H2 Admin UI server and open browser with the Admin UI URL)
+- Set JDBC URL to jdbc:h2:/path/to/payara/payara5/glassfish/domains/domain1/lib/databases/ejbtimer
+- Leave the other options as they are and log in, then execute your SQL
+- Then stop the h2.jar process


### PR DESCRIPTION
Having Removed Derby somehow the EJB Timer SQL Tables are missing. in case this is no bug as per:
https://github.com/payara/Payara/issues/4857

we would like to have that info as provided in the documenation.