### PR TITLE
How to connect to H2 with an SQL manager

### DIFF
--- a/docs/modules/ROOT/pages/documentation/payara-server/h2/h2.adoc
+++ b/docs/modules/ROOT/pages/documentation/payara-server/h2/h2.adoc
@@ -5,7 +5,7 @@ H2 is a Java-based Database which replaced Derby as the default database in Paya
 
 [[why-replace-derby]]
 == Why replace Derby?
-In terms of performance, Derby is one of the slowest  embedded databases as  
+In terms of performance, Derby is one of the slowest embedded databases as  
 compared to other H2, PostgresSQL, HSQLDB, etc. H2 also has a smaller disk footprint; the 
 size of a JAR file is around 1.5 MB.
 
@@ -30,3 +30,15 @@ asadmin> stop-database
 ----
 
 The above command will stop H2. 
+
+[[to-connect]]
+=== To connect to H2 DB databases
+
+To connect to an H2 DB database and execute SQL scripts, you should:
+
+- Stop Payara Server if running
+- Navigate to `/path/to/payara/payara5/h2db/bin` to find the h2db binaries
+- Execute `java -jar h2.jar` (this will start the H2 Admin UI server and open browser with the Admin UI URL)
+- In the browser, set JDBC URL to `jdbc:h2:/path/to/payara/payara5/glassfish/domains/domain1/lib/databases/ejbtimer` to connect to the EJB timer database (or change the path to connect to another DB)
+- Leave the other options as they are and log into the SQL console
+- Make sure to stop the `java -jar h2.jar` process before launching Payara Server


### PR DESCRIPTION
Replaces #62 to document how to connect to the H2 DBs in Payara Server with an SQL manager to execute SQL scripts or view the contents in the tables.