### PR TITLE
Docker Image documentation; updated and transferred from separate repository Readme

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -248,6 +248,8 @@
 *** xref:documentation/ecosystem/cloud-connectors/mqtt.adoc[MQTT]
 ** xref:documentation/ecosystem/security-connectors.adoc[Security Connectors]
 ** xref:documentation/ecosystem/docker-images.adoc[Docker Images]
+*** xref:documentation/ecosystem/docker-server-usage.adoc[Payara Server Docker Image Usage]
+*** xref:documentation/ecosystem/docker-micro-usage.adoc[Payara Micro Docker Image Usage]
 
 .User Guides
 * xref:documentation/user-guides/user-guides.adoc[User Guides Overview]

--- a/docs/modules/ROOT/pages/documentation/ecosystem/docker-images.adoc
+++ b/docs/modules/ROOT/pages/documentation/ecosystem/docker-images.adoc
@@ -14,7 +14,7 @@ https://hub.docker.com/r/payara/server-web/[Payara Server Web]::
 Docker Images are available here for the web profile of Payara Server.
 
 
-Payara Enterprise customers have access to a private Docker repository containing Docker Images containing the Payara Enterprise Edition. These images are maintained every month. They receive JDK updates, expired Security certificate rates are cleaned and OS updates can be requested.
+TIP: Payara Enterprise customers have access to a private Docker repository containing Docker Images containing the Payara Enterprise Edition. These images are maintained every month. They receive JDK updates, expired Security Certificates are removed and OS updates can be requested.
 
 xref:/documentation/ecosystem/docker-server-usage.adoc[Payara Server Docker Image usage]
 

--- a/docs/modules/ROOT/pages/documentation/ecosystem/docker-images.adoc
+++ b/docs/modules/ROOT/pages/documentation/ecosystem/docker-images.adoc
@@ -1,6 +1,6 @@
 = Docker Images
 
-Payara Services Limited provides Docker Images for the Payara Platform and updates them with every public release.
+Payara Services Limited provides Docker Images for the Payara Platform Community and creates new images for every community release.
 
 You can find the docker images located here:
 
@@ -12,3 +12,10 @@ Docker Images are available here for Payara Micro.
 
 https://hub.docker.com/r/payara/server-web/[Payara Server Web]::
 Docker Images are available here for the web profile of Payara Server.
+
+
+Payara Enterprise customers have access to a private Docker repository containing Docker Images containing the Payara Enterprise Edition. These images are maintained every month. They receive JDK updates, expired Security certificate rates are cleaned and OS updates can be requested.
+
+xref:/documentation/ecosystem/docker-server-usage.adoc[Payara Server Docker Image usage]
+
+xref:/documentation/ecosystem/docker-micro-usage.adoc[Payara Micro Docker Image usage]

--- a/docs/modules/ROOT/pages/documentation/ecosystem/docker-micro-usage.adoc
+++ b/docs/modules/ROOT/pages/documentation/ecosystem/docker-micro-usage.adoc
@@ -12,9 +12,28 @@ It runs Payara Micro without any applications, therefore accessing the HTTP serv
 
 You need to add your applications to the container and deploy them.
 
+It is always recommended to specify the tag name of the Docker Image that you like to run. Otherwise, you are running the latest version and might encounter some unwanted effects due to changes between versions.
+
+....
+docker run -p 8080:8080 payara/micro:{currentVersion}
+....
+
+
+=== JDK Version
+
+_Since Payara 5.2020.3_
+
+The Docker Images are available in 2 different flavours. The one is running on JDK 8 and the other has JDK 11 on board.
+
+The command used in the Quick start above, will start the Zulu JDK 8 version. If you need the Zulu JDK 11 version, you need to add the `-jdk11` suffix to the image name.
+
+....
+docker run -p 8080:8080 payara/micro-jdk11:{currentVersion}
+....
+
 === Open ports
 
-Most common default open ports that can be exposed outside of the container:
+Most common default open ports that can be exposed outside of the container are:
 
 * 8080 - HTTP listener
 * 8443 - HTTPS listener
@@ -28,7 +47,7 @@ There are number of ways how you can run your applications with Payara Micro wit
 
 * load applications from a mounted file-system (from a disk on the host system or on network)
 * derive a new docker image that also contains your applications on the file-system
-* load applications from a maven repository accessible from the dockar container
+* load applications from a maven repository accessible from the docker container
 
 ==== *Run from a mounted volume*
 
@@ -40,7 +59,7 @@ The following command will run Payara Micro docker container and will deploy app
 
 ....
 docker run -p 8080:8080 \
- -v ~/payara-micro/applications:/opt/payara/deployments payara/micro
+ -v ~/payara-micro/applications:/opt/payara/deployments payara/micro:{currentVersion}
 ....
 
 To run a specific application within the directory, you can modify the default entry point and use `--deploy` option followed by path to the application file:
@@ -48,7 +67,7 @@ To run a specific application within the directory, you can modify the default e
 ....
 docker run -p 8080:8080 \
  -v ~/payara-micro/applications:/opt/payara/deployments \
- payara/micro \
+ payara/micro:{currentVersion} \
  --deploy /opt/payara/deployments/myapplication.war
 ....
 
@@ -56,10 +75,10 @@ docker run -p 8080:8080 \
 
 You can extend the docker image to add your deployables into the `/opt/payara/deployments` directory and run the resulting docker image instead of the original one.
 
-The following example Dockerfile will build an image that deploys `myapplication.war` when Payara Micro is started:
+The following example Dockerfile will build an image that deploys `myapplication.war` when Payara Micro starts:
 
 ....
-FROM payara/micro
+FROM payara/micro:{currentVersion}
 
 COPY myapplication.war $DEPLOY_DIR
 ....
@@ -71,7 +90,7 @@ If your application is already in a maven repository, you can run it with Payara
 The following command runs Payara Micro in the docker image and runs an application stored in a maven repository. The application group is `fish.payara.examples`, artifact name is `my-application`, and version is `1.0-SNAPSHOT`. The maven repository is available on host `172.17.0.10`:
 
 ....
-docker docker run -p 8080:8080 payara/micro \
+docker docker run -p 8080:8080 payara/micro:{currentVersion} \
  --deployFromGAV "fish.payara.examples:my-application:1.0-SNAPSHOT" \
  --additionalRepository https://172.17.0.10/content/repositories/snapshots
 ....
@@ -87,7 +106,7 @@ Some examples of how it can be used :
 
 ....
 docker run -p 8080:8080 \
- -v ~/payara-micro/applications:/opt/payara/deployments payara/micro  \
+ -v ~/payara-micro/applications:/opt/payara/deployments payara/micro:{currentVersion}  \
  --deploymentDir /opt/payara/deployments  \
  --contextroot myRoot
 ....
@@ -97,7 +116,7 @@ Deploys the (first) application within the mounted directory _~/payara-micro/app
 ....
 docker run -p 8080:8080 \
  -v ~/payara-micro/applications:/opt/payara/deployments \
- payara/micro \
+ payara/micro:{currentVersion} \
  --deploy /opt/payara/deployments/myapplication.war \
  --contextroot ROOT
 ....
@@ -105,7 +124,7 @@ docker run -p 8080:8080 \
 Deploys the _myapplication.war_ to the root.
 
 ....
-FROM payara/micro
+FROM payara/micro:{currentVersion}
 
 COPY myapplication.war $DEPLOY_DIR
 
@@ -120,9 +139,27 @@ By default the image has the Data Grid enabled and instances of Payara Micro wil
 
 To speed up boot time the Data Grid can be disabled by modifying the CMD to add `--nocluster`
 
+== Configuration
+
+=== Environment Variables
+
+The following environment variables are available to configure Payara Micro. 
+
+* `MEM_MAX_RAM_PERCENTAGE` - Value for the JVM parameter `-XX:MaxRAMPercentage` that indicate the percentage of memory assigned to the container that can be used by the Java Process. By default this is _70_.
+* `MEM_XSS` - Defines the value of the Stack size, used in the JVM parameter `-Xss`. The default value is _512k_.
+* `JVM_ARGS` - Specifies a list of JVM arguments which will be passed to Payara in the `entrypoint.sh` script.
+
+The following environment variables shouldn’t be changed, but may be helpful in your Dockerfile.
+
+[width="100%",cols="29%,50%,21%",options="header",]
+|===
+|Variable name |Value |Description
+|`HOME_DIR` |`/opt/payara` |The directory containing the Payara Micro binary
+|`PAYARA_DIR` |`/opt/payara` |The root directory of the Payara installation
+|`SCRIPT_DIR` |`/opt/payara` |The directory where the `entrypoint.sh` script can be found.
+|===
+
 == Details
 
 Payara Micro JAR file `payara-micro.jar` is located in the `/opt/payara/` directory. This directory is the default working directory of the docker image. The directory name is deliberately free of any versioning so that any scripts written to work with one version can be seamlessly migrated to the latest docker image.
 
-* Full and Web editions are derived from the OpenJDK 8 images with a Debian Jessie base
-* Micro editions are built on OpenJDK 8 images with an Alpine Linux base to keep image size as small as possible.

--- a/docs/modules/ROOT/pages/documentation/ecosystem/docker-micro-usage.adoc
+++ b/docs/modules/ROOT/pages/documentation/ecosystem/docker-micro-usage.adoc
@@ -1,0 +1,128 @@
+== Usage
+
+=== Quick start
+
+To start the docker container and run Payara Micro:
+
+....
+docker run -p 8080:8080 payara/micro
+....
+
+It runs Payara Micro without any applications, therefore accessing the HTTP server bound to port 8080 will just return HTTP code 404 - Not Found.
+
+You need to add your applications to the container and deploy them.
+
+=== Open ports
+
+Most common default open ports that can be exposed outside of the container:
+
+* 8080 - HTTP listener
+* 8443 - HTTPS listener
+* 6900 - Hazelcast cluster communication port
+
+=== Application deployment
+
+Payara Micro deploys applications during startup, according to provided command-line arguments. It does not open any port to deploy applications during runtime on request.
+
+There are number of ways how you can run your applications with Payara Micro within docker:
+
+* load applications from a mounted file-system (from a disk on the host system or on network)
+* derive a new docker image that also contains your applications on the file-system
+* load applications from a maven repository accessible from the dockar container
+
+==== *Run from a mounted volume*
+
+Once we mount a volume that contains our applications, Payara Micro can access the applications and run them through the local file-system.
+
+The docker image already contains `/opt/payara/deployments` directory, which can be bound to a directory with your applications.
+
+The following command will run Payara Micro docker container and will deploy applications that exist in the directory `~/payara-micro/applications` on the host file-system:
+
+....
+docker run -p 8080:8080 \
+ -v ~/payara-micro/applications:/opt/payara/deployments payara/micro
+....
+
+To run a specific application within the directory, you can modify the default entry point and use `--deploy` option followed by path to the application file:
+
+....
+docker run -p 8080:8080 \
+ -v ~/payara-micro/applications:/opt/payara/deployments \
+ payara/micro \
+ --deploy /opt/payara/deployments/myapplication.war
+....
+
+==== *Build a new docker image to run your application*
+
+You can extend the docker image to add your deployables into the `/opt/payara/deployments` directory and run the resulting docker image instead of the original one.
+
+The following example Dockerfile will build an image that deploys `myapplication.war` when Payara Micro is started:
+
+....
+FROM payara/micro
+
+COPY myapplication.war $DEPLOY_DIR
+....
+
+==== *Run from a maven repository*
+
+If your application is already in a maven repository, you can run it with Payara Micro in the docker very easily. Payara Micro knows how to download an artifact from a maven repository and run it directly. You just need to provide an alternative entry point
+
+The following command runs Payara Micro in the docker image and runs an application stored in a maven repository. The application group is `fish.payara.examples`, artifact name is `my-application`, and version is `1.0-SNAPSHOT`. The maven repository is available on host `172.17.0.10`:
+
+....
+docker docker run -p 8080:8080 payara/micro \
+ --deployFromGAV "fish.payara.examples:my-application:1.0-SNAPSHOT" \
+ --additionalRepository https://172.17.0.10/content/repositories/snapshots
+....
+
+==== *Define context root*
+
+_Since Payara Micro 5.191_
+
+
+The context root of the deployed application(s) is determined based on the file name of the artifact which is deployed. Form Payara Micro version 5.191 on, you can explicitly define the value of the context root using the `--contextroot` option, including deploying the application on the root itself ( `/`, specify *ROOT* as option value).
+
+Some examples of how it can be used :
+
+....
+docker run -p 8080:8080 \
+ -v ~/payara-micro/applications:/opt/payara/deployments payara/micro  \
+ --deploymentDir /opt/payara/deployments  \
+ --contextroot myRoot
+....
+
+Deploys the (first) application within the mounted directory _~/payara-micro/applications_ under the root context _/myRoot_.
+
+....
+docker run -p 8080:8080 \
+ -v ~/payara-micro/applications:/opt/payara/deployments \
+ payara/micro \
+ --deploy /opt/payara/deployments/myapplication.war \
+ --contextroot ROOT
+....
+
+Deploys the _myapplication.war_ to the root.
+
+....
+FROM payara/micro
+
+COPY myapplication.war $DEPLOY_DIR
+
+CMD ["--deploymentDir", "/opt/payara/deployments", "--contextroot", "my"]
+....
+
+Creates a new Docker Image which results in the deployment of the _myapplication.war_ under the root context _/my_.
+
+== Speeding up Boot by disabling the Data Grid
+
+By default the image has the Data Grid enabled and instances of Payara Micro will form a Data Grid if they can see each other over multicast. Typically this will occur on a single host.
+
+To speed up boot time the Data Grid can be disabled by modifying the CMD to add `--nocluster`
+
+== Details
+
+Payara Micro JAR file `payara-micro.jar` is located in the `/opt/payara/` directory. This directory is the default working directory of the docker image. The directory name is deliberately free of any versioning so that any scripts written to work with one version can be seamlessly migrated to the latest docker image.
+
+* Full and Web editions are derived from the OpenJDK 8 images with a Debian Jessie base
+* Micro editions are built on OpenJDK 8 images with an Alpine Linux base to keep image size as small as possible.

--- a/docs/modules/ROOT/pages/documentation/ecosystem/docker-micro-usage.adoc
+++ b/docs/modules/ROOT/pages/documentation/ecosystem/docker-micro-usage.adoc
@@ -8,7 +8,7 @@ To start the docker container and run Payara Micro:
 docker run -p 8080:8080 payara/micro
 ....
 
-It runs Payara Micro without any applications, therefore accessing the HTTP server bound to port 8080 will just return HTTP code 404 - Not Found.
+It runs Payara Micro without any applications, therefore accessing the HTTP server bound to port 8080 will just return HTTP code 404 - Not Found. The Payara Micro process runs under the `payara` user.
 
 You need to add your applications to the container and deploy them.
 
@@ -23,12 +23,12 @@ docker run -p 8080:8080 payara/micro:{currentVersion}
 
 _Since Payara 5.2020.3_
 
-The Docker Images are available in 2 different flavours. The one is running on JDK 8 and the other has JDK 11 on board.
+The Docker Images are available in 2 different flavours; either based on JDK 8 (tags without a suffix) or JDK 11 (tags with the `-jdk11` suffix).
 
 The command used in the Quick start above, will start the Zulu JDK 8 version. If you need the Zulu JDK 11 version, you need to add the `-jdk11` suffix to the image name.
 
 ....
-docker run -p 8080:8080 payara/micro-jdk11:{currentVersion}
+docker run -p 8080:8080 payara/micro:{currentVersion}-jdk11
 ....
 
 === Open ports
@@ -100,7 +100,7 @@ docker docker run -p 8080:8080 payara/micro:{currentVersion} \
 _Since Payara Micro 5.191_
 
 
-The context root of the deployed application(s) is determined based on the file name of the artifact which is deployed. Form Payara Micro version 5.191 on, you can explicitly define the value of the context root using the `--contextroot` option, including deploying the application on the root itself ( `/`, specify *ROOT* as option value).
+The context root of the deployed application(s) is determined based on the file name of the artifact which is deployed. You can explicitly define the value of the context root using the `--contextroot` option, including deploying the application on the root itself ( `/`, specify *ROOT* as option value).
 
 Some examples of how it can be used :
 
@@ -135,9 +135,9 @@ Creates a new Docker Image which results in the deployment of the _myapplication
 
 == Speeding up Boot by disabling the Data Grid
 
-By default the image has the Data Grid enabled and instances of Payara Micro will form a Data Grid if they can see each other over multicast. Typically this will occur on a single host.
+By default the image has the Data Grid enabled and instances of Payara Micro will form a Data Grid if they can see each other over multicast.
 
-To speed up boot time the Data Grid can be disabled by modifying the CMD to add `--nocluster`
+If you don't intend to form a cluster and want to speed up boot time, you can disable Data Grid by modifying the CMD to add `--nocluster`.
 
 == Configuration
 
@@ -145,7 +145,7 @@ To speed up boot time the Data Grid can be disabled by modifying the CMD to add 
 
 The following environment variables are available to configure Payara Micro. 
 
-* `MEM_MAX_RAM_PERCENTAGE` - Value for the JVM parameter `-XX:MaxRAMPercentage` that indicate the percentage of memory assigned to the container that can be used by the Java Process. By default this is _70_.
+* `MEM_MAX_RAM_PERCENTAGE` - Value for the JVM parameter `-XX:MaxRAMPercentage` that indicates the percentage of memory assigned to the container that can be used by the Java Process. By default this is _70_.
 * `MEM_XSS` - Defines the value of the Stack size, used in the JVM parameter `-Xss`. The default value is _512k_.
 * `JVM_ARGS` - Specifies a list of JVM arguments which will be passed to Payara in the `entrypoint.sh` script.
 

--- a/docs/modules/ROOT/pages/documentation/ecosystem/docker-server-usage.adoc
+++ b/docs/modules/ROOT/pages/documentation/ecosystem/docker-server-usage.adoc
@@ -1,0 +1,143 @@
+== Usage
+
+=== Quick start
+
+To boot the default domain with HTTP listener exported on port 8080:
+
+....
+docker run -p 8080:8080 payara/server-full
+....
+
+The Docker container specifies the default entry point, starts the domain `production` in foreground so that Payara Server becomes the main process. The tini tool is used to guarantee that the Payara Server process runs seamlessly as the main docker process.
+
+=== Open ports
+
+Most common default open ports that can be exposed outside of the container:
+
+* 8080 - HTTP listener
+* 8181 - HTTPS listener
+* 4848 - HTTPS admin listener
+* 9009 - Debug port
+
+=== Administration
+
+To boot and export admin interface on port 4848 (and also the default HTTP listener on port 8080):
+
+....
+docker run -p 4848:4848 -p 8080:8080 payara/server-full
+....
+
+Because Payara Server doesn’t allow insecure remote admin connections (outside of a Docker container), the admin interface is secured by default, accessible using HTTPS on the host machine: https://localhost:4848 The default user and password is `admin`.
+
+=== Application deployment
+
+==== Deploy appllications from a folder on startup
+
+The default Docker entry point will scan the folder `$DEPLOY_DIR` (by default points to `/opt/payara/deployments`) for files and folders and deploy them automatically after the domain is started. If RAR files are found in that directory, they will be deployed before any other file.
+
+In order to deploy applications, you can mount the `$DEPLOY_DIR` (`/opt/payara/deployments`) folder as a docker volume to a directory, which contains your applications. The following will run Payara Server in the docker and will start applications that exist in the directory `~/payara/apps` on the local file-system:
+
+....
+docker run -p 8080:8080 -v ~/payara/apps:/opt/payara/deployments payara/server-full
+....
+
+In order to build a Docker image that contains your applications and starts them automatically, you can copy the applications into the `$DEPLOY_DIR` directory. and run the resulting docker image instead of the original one.
+
+The following example Dockerfile will build an image that starts Payara Server and deploys `myapplication.war` when the Docker container is started:
+
+....
+FROM payara/server-full
+
+COPY myapplication.war $DEPLOY_DIR
+....
+
+You can now build the Docker image and run the application `myapplication.war` with the following commands:
+
+....
+docker build -t mycompany/myapplication .
+....
+
+....
+docker run -p 8080:8080 mycompany/myapplication
+....
+
+==== Remote deployment
+
+If admin port is exposed, it is possible to deploy applications remotely, outside of the docker container, by means of admin console and asadmin tool as usual. See the _Administration_ section above for information how to access the admin interface remotely.
+
+=== Configuration
+
+==== Environment Variables
+
+The following environment variables are available to configure Payara Server. When edited either in a `Dockerfile` or before the `startInForeground.sh` script is ran, they will change the behaviour of the Payara Server instance.
+
+* `JVM_ARGS` - Specifies a list of JVM arguments which will be passed to Payara in the `startInForeground.sh` script.
+* `DEPLOY_PROPS` - Specifies a list of properties to be passed with the deploy commands generated in the `generate_deploy_commands.sh` script, For example `'--properties=implicitCdiEnabled=false'`.
+* `POSTBOOT_COMMANDS` - The name of the file containing post boot commands for the Payara Server instance. This is the file written to in the `generate_deploy_commands.sh` script.
+* `PREBOOT_COMMANDS` - The name of the file containing pre boot commands for the Payara Server instance.
+* `PAYARA_ARGS` - additional arguments to the `start-domain` command that starts the server. Use this only if it’s not enough to specify the configuration using the `POSTBOOT_COMMANDS` or `PREBOOT_COMMANDS` file
+* `AS_ADMIN_MASTERPASSWORD` - The master password to pass to Payara Server. This is overriden if one is specified in the `$PASSWORD_FILE`.
+
+The following environment variables shouldn’t be changed, but may be helpful in your Dockerfile.
+
+[width="100%",cols="29%,50%,21%",options="header",]
+|===
+|Variable name |Value |Description
+|`HOME_DIR` |`/opt/payara` |The home directory for the `payara` user
+|`PAYARA_DIR` |`/opt/payara/appserver` |The root directory of the Payara installation
+|`SCRIPT_DIR` |`/opt/payara/scripts` |The directory where the `generate_deploy_commands.sh` and `startInForeground.sh` scripts can be found.
+|`CONFIG_DIR` |`/opt/payara/config` |The directory where the post and pre boot files are generated to by default.
+|`DEPLOY_DIR` |`/opt/payara/deployments` |The directory where applications are searched for in `generate_deploy_commands.sh` script.
+|`PASSWORD_FILE` |`/opt/payara/passwordFile` |The location of the password file for asadmin. This can be passed to asadmin using the `--passwordfile` parameter.
+|===
+
+==== Custom asadmin commands at server startup time
+
+It’s possible to run a set of custom asadmin commands during Payara server startup. You can either by specify the `PREBOOT_COMMANDS` or `POSTBOOT_COMMANDS` environment variables to point to the absolute path of your custom boot command file, or you can just copy a custom file to the expected path (default paths are `$CONFIG_DIR/post-boot-commands.asadmin` and `$CONFIG_DIR/pre-boot-commands.asadmin`).
+
+For example, the following command will execute commands defined in the `/local/path/with/boot/file` directory mounted as a volume:
+
+....
+docker run -p 8080:8080 -v /local/path/with/boot/file:/config -e POSTBOOT_COMMANDS=/config/post-boot-commands.asadmin payara/server-full
+....
+
+Alternatively, the following Dockerfile will build an image which will execute the commands in the `post-boot-commands.asadmin` file:
+
+....
+FROM payara/server-full
+
+COPY post-boot-commands.asadmin $POSTBOOT_COMMANDS
+....
+
+==== Execution of custom scripts before server startup
+
+In cases this is not sufficient, you can add your own init scripts to the `${SCRIPT_DIR}`. You need to follow the naming convention: `init_<num>_<text>.sh`, where `<num>` gives you a simple option to run scripts in order. Be aware that the default deploy commands script is using this, too.
+
+If you do not want to create a sub-image, you can also mount a volume to `/opt/payara/scripts/init.d` and each `*.sh` file in there will be executed in standard file order.
+
+*Please note:* you can combine both approaches, but please keep in mind that scripts from `init.d` will run _after_ those from subimages!
+
+=== The default Docker entry point
+
+The default entry point is https://github.com/krallin/tini[tini], as the JVM should not run as PID 1. The default `CMD` argument for `tini` runs the `bin/entrypoint.sh` script in _exec_ mode, which in turn runs the following:
+
+* `${SCRIPT_DIR}/init_1_generate_deploy_commands.sh`. This script outputs deploy commands to the post boot command file located at `$POSTBOOT_COMMANDS` (default `$CONFIG_DIR/post-boot-commands.asadmin`). If the deploy commands are already found in that file, this script does nothing.
+* `${SCRIPT_DIR}/init_*.sh` scripts that you may provide for custom use as waiting or initializing during startup, *before* Glassfish kicks in.
+* `${SCRIPT_DIR}/startInForeground.sh`. This script starts the server in the foreground, in a manner that allows the Payara instance to be controlled by the docker host. The server will run the pre boot commands found in the file at `$PREBOOT_COMMANDS`, as well as the post boot commands found in the file at `$POSTBOOT_COMMANDS`.
+
+==== Testing, browsing and configuring a container instance
+
+For testing or other purposes, you can override the default entrypoint. For example, the following command will start the container at a bash prompt, without starting Payara server. It allows you to browse the image and configure the Payara Server instance as you like:
+
+....
+docker run -p 8080:8080 -it payara/server-full bash
+....
+
+== Details
+
+Payara Server installation is located in the `/opt/payara` directory. This directory is the default working directory of the docker image. The directory name is deliberately free of any versioning so that any scripts written to work with one version can be seamlessly migrated to the latest docker image.
+
+* Full and Web editions are derived from the OpenJDK 8 images with a Debian Jessie base
+* Micro editions are built on OpenJDK 8 images with an Alpine Linux base to keep image size as small as possible.
+
+

--- a/docs/modules/ROOT/pages/documentation/ecosystem/docker-server-usage.adoc
+++ b/docs/modules/ROOT/pages/documentation/ecosystem/docker-server-usage.adoc
@@ -8,7 +8,7 @@ To boot the default domain with HTTP listener exported on port 8080:
 docker run -p 8080:8080 payara/server-full
 ....
 
-The Docker container specifies the default entry point, starts the domain `production` in the foreground so that Payara Server becomes the main process. The _tini_ tool is used to guarantee that the Payara Server process runs seamlessly as the main docker process.
+The Docker container specifies the default entry point, starts the domain `production` in the foreground so that Payara Server becomes the main process. The _tini_ tool is used to guarantee that the Payara Server process runs seamlessly as the main docker process. The Payara Server process runs under the `payara` user.
 
 It is always recommended to specify the tag name of the Docker Image that you like to run. Otherwise, you are running the latest version and might encounter some unwanted effects due to changes between versions.
 
@@ -21,12 +21,11 @@ docker run -p 8080:8080 payara/server-full:{currentVersion}
 
 _Since Payara 5.2020.3_
 
-The Docker Images are available in 2 different flavours. The one is running on JDK 8 and the other has JDK 11 on board.
+The Docker Images are available in 2 different flavours; either based on JDK 8 (tags without a suffix) or JDK 11 (tags with the `-jdk11` suffix).
 
-The command used in the Quick start above, will start the Zulu JDK 8 version. If you need the Zulu JDK 11 version, you need to add the `-jdk11` suffix to the image name.
-
+The command used in the Quick start above will start the Zulu JDK 8 version. If you need to run Zulu JDK 11, you need to add the `-jdk11` suffix to the tag name.
 ....
-docker run -p 8080:8080 payara/server-full-jdk11:{currentVersion}
+docker run -p 8080:8080 payara/server-full:{currentVersion}-jdk11
 ....
 
 === Payara Versions
@@ -55,7 +54,7 @@ To boot and export admin interface on port 4848 (and also the default HTTP liste
 docker run -p 4848:4848 -p 8080:8080 payara/server-full:{currentVersion}
 ....
 
-Because Payara Server doesn’t allow insecure remote admin connections (outside of a Docker container), the admin interface is secured by default, accessible using HTTPS on the host machine: https://localhost:4848 The default user and password is `admin`.
+Because Payara Server doesn’t allow insecure remote admin connections (outside of a Docker container), the admin interface is secured by default, accessible using HTTPS on the host machine: https://localhost:4848; The default user and password is `admin`.
 
 === Application deployment
 
@@ -69,9 +68,9 @@ In order to deploy applications, you can mount the `$DEPLOY_DIR` (`/opt/payara/d
 docker run -p 8080:8080 -v ~/payara/apps:/opt/payara/deployments payara/server-full:{currentVersion}
 ....
 
-In order to build a Docker image that contains your applications and starts them automatically, you can copy the applications into the `$DEPLOY_DIR` directory. and run the resulting docker image instead of the original one.
+In order to build a Docker image that contains your applications and starts them automatically, you can copy the applications into the `$DEPLOY_DIR` directory and run the resulting docker image instead of the original one.
 
-The following example Dockerfile will build an image that starts Payara Server and deploys `myapplication.war` when the Docker container is started:
+The following example _Dockerfile_ will build an image that starts Payara Server and deploys `myapplication.war` when the Docker container is started:
 
 ....
 FROM payara/server-full:{currentVersion}
@@ -97,17 +96,16 @@ If admin port is exposed, it is possible to deploy applications remotely, outsid
 
 ==== *Environment Variables*
 
-The following environment variables are available to configure Payara Server. When edited either in a `Dockerfile` or before the `startInForeground.sh` script is ran, they will change the behaviour of the Payara Server instance.
+The following environment variables are available to configure Payara Server to change the behaviour of the Payara Server instance. They can be either specified in the `Dockerfile`, passed to the `docker run` command via the `--env` or `--env-file` arguments or modified by an init script before the `startInForeground.sh` script is executed:
 
 * `POSTBOOT_COMMANDS` - The name of the file containing post boot commands for the Payara Server instance. This is the file written to in the `generate_deploy_commands.sh` script.
-* `MEM_MAX_RAM_PERCENTAGE` - Value for the JVM parameter `-XX:MaxRAMPercentage` that indicate the percentage of memory assigned to the container that can be used by the Java Process. By default this is _70_.
+* `MEM_MAX_RAM_PERCENTAGE` - Value for the JVM parameter `-XX:MaxRAMPercentage` that indicates the percentage of memory assigned to the container that can be used by the Java Process. By default this is _70_.
 * `MEM_XSS` - Defines the value of the Stack size, used in the JVM parameter `-Xss`. The default value is _512k_.
 * `DEPLOY_PROPS` - Specifies a list of properties to be passed with the deploy commands generated in the `generate_deploy_commands.sh` script, For example `'--properties=implicitCdiEnabled=false'`.
 * `PREBOOT_COMMANDS` - The name of the file containing pre boot commands for the Payara Server instance.
-* `ADMIN_PASSWORD` - The password used for accessing the server in combination with user name defined in  `ADMIN-USER`. By default this is `admin`.
+* `ADMIN_PASSWORD` - The password used for accessing the server in combination with user name defined in  `ADMIN_USER`. By default this is `admin`.
 * `PAYARA_ARGS` - additional arguments to the `start-domain` command that starts the server. Use this only if it’s not enough to specify the configuration using the `POSTBOOT_COMMANDS` or `PREBOOT_COMMANDS` file
 * `JVM_ARGS` - Specifies a list of JVM arguments which will be passed to Payara in the `startInForeground.sh` script.
-* `AS_ADMIN_MASTERPASSWORD` - The master password to pass to Payara Server. This is overriden if one is specified in the `$PASSWORD_FILE`.
 
 The following environment variables shouldn’t be changed, but may be helpful in your Dockerfile.
 
@@ -122,11 +120,12 @@ The following environment variables shouldn’t be changed, but may be helpful i
 |`PASSWORD_FILE` |`/opt/payara/passwordFile` |The location of the password file for asadmin. This can be passed to asadmin using the `--passwordfile` parameter.
 |`ADMIN_USER` |`admin` |The user name for accessing the server with secure administration.
 |`DOMAIN_NAME` |`production` | The name of the domain running within the container. 
+|`AS_ADMIN_MASTERPASSWORD` |`changit` |  The master password to pass to Payara Server. This is overriden if one is specified in the `$PASSWORD_FILE`.
 |===
 
 ==== *Custom asadmin commands at server startup time*
 
-It’s possible to run a set of custom asadmin commands during Payara server startup. You can either by specify the `PREBOOT_COMMANDS` or `POSTBOOT_COMMANDS` environment variables to point to the absolute path of your custom boot command file, or you can just copy a custom file to the expected path (default paths are `$CONFIG_DIR/post-boot-commands.asadmin` and `$CONFIG_DIR/pre-boot-commands.asadmin`).
+It’s possible to run a set of custom asadmin commands during Payara server startup. You can either specify the `PREBOOT_COMMANDS` or `POSTBOOT_COMMANDS` environment variables to point to the absolute path of your custom boot command file, or you can just copy a custom file to the expected path (default paths are `$CONFIG_DIR/post-boot-commands.asadmin` and `$CONFIG_DIR/pre-boot-commands.asadmin`).
 
 For example, the following command will execute commands defined in the `/local/path/with/boot/file` directory mounted as a volume:
 
@@ -144,18 +143,18 @@ COPY post-boot-commands.asadmin $POSTBOOT_COMMANDS
 
 ==== *Execution of custom scripts before server startup*
 
-In cases this is not sufficient, you can add your own init scripts to the `${SCRIPT_DIR}`. You need to follow the naming convention: `init_<num>_<text>.sh`, where `<num>` gives you a simple option to run scripts in order. Be aware that the default deploy commands script is using this, too.
+In cases this is not sufficient, you can add your own init scripts to the `${SCRIPT_DIR}`. You need to follow the naming convention: `init_<num>_<text>.sh`, where `<num>` gives you a simple option to run scripts in order. Be aware that the default deploy commands script is using this naming too.
 
 If you do not want to create a sub-image, you can also mount a volume to `/opt/payara/scripts/init.d` and each `*.sh` file in there will be executed in standard file order.
 
-*Please note:* you can combine both approaches, but please keep in mind that scripts from `init.d` will run _after_ those from subimages!
+*CAUTION:* you can combine both approaches, but please keep in mind that scripts from `init.d` will run _after_ those from subimages!
 
 === *The default Docker entry point*
 
 The default entry point is https://github.com/krallin/tini[tini], as the JVM should not run as PID 1. The default `CMD` argument for `tini` runs the `bin/entrypoint.sh` script in _exec_ mode, which in turn runs the following:
 
 * `${SCRIPT_DIR}/init_1_generate_deploy_commands.sh`. This script outputs deploy commands to the post boot command file located at `$POSTBOOT_COMMANDS` (default `$CONFIG_DIR/post-boot-commands.asadmin`). If the deploy commands are already found in that file, this script does nothing.
-* `${SCRIPT_DIR}/init_*.sh` scripts that you may provide for custom use as waiting or initializing during startup, *before* Glassfish kicks in.
+* `${SCRIPT_DIR}/init_*.sh` scripts that you may provide for custom use as waiting or initializing during startup, *before* Payara Server starts.
 * `${SCRIPT_DIR}/startInForeground.sh`. This script starts the server in the foreground, in a manner that allows the Payara instance to be controlled by the docker host. The server will run the pre boot commands found in the file at `$PREBOOT_COMMANDS`, as well as the post boot commands found in the file at `$POSTBOOT_COMMANDS`.
 
 ==== *Testing, browsing and configuring a container instance*

--- a/docs/modules/ROOT/pages/documentation/ecosystem/docker-server-usage.adoc
+++ b/docs/modules/ROOT/pages/documentation/ecosystem/docker-server-usage.adoc
@@ -8,11 +8,39 @@ To boot the default domain with HTTP listener exported on port 8080:
 docker run -p 8080:8080 payara/server-full
 ....
 
-The Docker container specifies the default entry point, starts the domain `production` in foreground so that Payara Server becomes the main process. The tini tool is used to guarantee that the Payara Server process runs seamlessly as the main docker process.
+The Docker container specifies the default entry point, starts the domain `production` in the foreground so that Payara Server becomes the main process. The _tini_ tool is used to guarantee that the Payara Server process runs seamlessly as the main docker process.
+
+It is always recommended to specify the tag name of the Docker Image that you like to run. Otherwise, you are running the latest version and might encounter some unwanted effects due to changes between versions.
+
+....
+docker run -p 8080:8080 payara/server-full:{currentVersion}
+....
+
+
+=== JDK Version
+
+_Since Payara 5.2020.3_
+
+The Docker Images are available in 2 different flavours. The one is running on JDK 8 and the other has JDK 11 on board.
+
+The command used in the Quick start above, will start the Zulu JDK 8 version. If you need the Zulu JDK 11 version, you need to add the `-jdk11` suffix to the image name.
+
+....
+docker run -p 8080:8080 payara/server-full-jdk11:{currentVersion}
+....
+
+=== Payara Versions
+
+Besides the full profile version, the Payara Server Web version is also available as Docker Image.  The Docker Image name is:
+
+....
+docker run -p 8080:8080 payara/server-web:{currentVersion}
+....
+
 
 === Open ports
 
-Most common default open ports that can be exposed outside of the container:
+Most common default open ports that can be exposed outside of the container are:
 
 * 8080 - HTTP listener
 * 8181 - HTTPS listener
@@ -24,21 +52,21 @@ Most common default open ports that can be exposed outside of the container:
 To boot and export admin interface on port 4848 (and also the default HTTP listener on port 8080):
 
 ....
-docker run -p 4848:4848 -p 8080:8080 payara/server-full
+docker run -p 4848:4848 -p 8080:8080 payara/server-full:{currentVersion}
 ....
 
 Because Payara Server doesn’t allow insecure remote admin connections (outside of a Docker container), the admin interface is secured by default, accessible using HTTPS on the host machine: https://localhost:4848 The default user and password is `admin`.
 
 === Application deployment
 
-==== Deploy appllications from a folder on startup
+==== *Deploy applications from a folder on startup*
 
 The default Docker entry point will scan the folder `$DEPLOY_DIR` (by default points to `/opt/payara/deployments`) for files and folders and deploy them automatically after the domain is started. If RAR files are found in that directory, they will be deployed before any other file.
 
 In order to deploy applications, you can mount the `$DEPLOY_DIR` (`/opt/payara/deployments`) folder as a docker volume to a directory, which contains your applications. The following will run Payara Server in the docker and will start applications that exist in the directory `~/payara/apps` on the local file-system:
 
 ....
-docker run -p 8080:8080 -v ~/payara/apps:/opt/payara/deployments payara/server-full
+docker run -p 8080:8080 -v ~/payara/apps:/opt/payara/deployments payara/server-full:{currentVersion}
 ....
 
 In order to build a Docker image that contains your applications and starts them automatically, you can copy the applications into the `$DEPLOY_DIR` directory. and run the resulting docker image instead of the original one.
@@ -46,7 +74,7 @@ In order to build a Docker image that contains your applications and starts them
 The following example Dockerfile will build an image that starts Payara Server and deploys `myapplication.war` when the Docker container is started:
 
 ....
-FROM payara/server-full
+FROM payara/server-full:{currentVersion}
 
 COPY myapplication.war $DEPLOY_DIR
 ....
@@ -54,28 +82,31 @@ COPY myapplication.war $DEPLOY_DIR
 You can now build the Docker image and run the application `myapplication.war` with the following commands:
 
 ....
-docker build -t mycompany/myapplication .
+docker build -t mycompany/myapplication:1.0 .
 ....
 
 ....
-docker run -p 8080:8080 mycompany/myapplication
+docker run -p 8080:8080 mycompany/myapplication:1.0
 ....
 
-==== Remote deployment
+==== *Remote deployment*
 
 If admin port is exposed, it is possible to deploy applications remotely, outside of the docker container, by means of admin console and asadmin tool as usual. See the _Administration_ section above for information how to access the admin interface remotely.
 
 === Configuration
 
-==== Environment Variables
+==== *Environment Variables*
 
 The following environment variables are available to configure Payara Server. When edited either in a `Dockerfile` or before the `startInForeground.sh` script is ran, they will change the behaviour of the Payara Server instance.
 
-* `JVM_ARGS` - Specifies a list of JVM arguments which will be passed to Payara in the `startInForeground.sh` script.
-* `DEPLOY_PROPS` - Specifies a list of properties to be passed with the deploy commands generated in the `generate_deploy_commands.sh` script, For example `'--properties=implicitCdiEnabled=false'`.
 * `POSTBOOT_COMMANDS` - The name of the file containing post boot commands for the Payara Server instance. This is the file written to in the `generate_deploy_commands.sh` script.
+* `MEM_MAX_RAM_PERCENTAGE` - Value for the JVM parameter `-XX:MaxRAMPercentage` that indicate the percentage of memory assigned to the container that can be used by the Java Process. By default this is _70_.
+* `MEM_XSS` - Defines the value of the Stack size, used in the JVM parameter `-Xss`. The default value is _512k_.
+* `DEPLOY_PROPS` - Specifies a list of properties to be passed with the deploy commands generated in the `generate_deploy_commands.sh` script, For example `'--properties=implicitCdiEnabled=false'`.
 * `PREBOOT_COMMANDS` - The name of the file containing pre boot commands for the Payara Server instance.
+* `ADMIN_PASSWORD` - The password used for accessing the server in combination with user name defined in  `ADMIN-USER`. By default this is `admin`.
 * `PAYARA_ARGS` - additional arguments to the `start-domain` command that starts the server. Use this only if it’s not enough to specify the configuration using the `POSTBOOT_COMMANDS` or `PREBOOT_COMMANDS` file
+* `JVM_ARGS` - Specifies a list of JVM arguments which will be passed to Payara in the `startInForeground.sh` script.
 * `AS_ADMIN_MASTERPASSWORD` - The master password to pass to Payara Server. This is overriden if one is specified in the `$PASSWORD_FILE`.
 
 The following environment variables shouldn’t be changed, but may be helpful in your Dockerfile.
@@ -83,33 +114,35 @@ The following environment variables shouldn’t be changed, but may be helpful i
 [width="100%",cols="29%,50%,21%",options="header",]
 |===
 |Variable name |Value |Description
-|`HOME_DIR` |`/opt/payara` |The home directory for the `payara` user
-|`PAYARA_DIR` |`/opt/payara/appserver` |The root directory of the Payara installation
+|`HOME_DIR` |`/opt/payara` |The home directory for the `payara` user.
+|`PAYARA_DIR` |`/opt/payara/appserver` |The root directory of the Payara installation.
 |`SCRIPT_DIR` |`/opt/payara/scripts` |The directory where the `generate_deploy_commands.sh` and `startInForeground.sh` scripts can be found.
 |`CONFIG_DIR` |`/opt/payara/config` |The directory where the post and pre boot files are generated to by default.
 |`DEPLOY_DIR` |`/opt/payara/deployments` |The directory where applications are searched for in `generate_deploy_commands.sh` script.
 |`PASSWORD_FILE` |`/opt/payara/passwordFile` |The location of the password file for asadmin. This can be passed to asadmin using the `--passwordfile` parameter.
+|`ADMIN_USER` |`admin` |The user name for accessing the server with secure administration.
+|`DOMAIN_NAME` |`production` | The name of the domain running within the container. 
 |===
 
-==== Custom asadmin commands at server startup time
+==== *Custom asadmin commands at server startup time*
 
 It’s possible to run a set of custom asadmin commands during Payara server startup. You can either by specify the `PREBOOT_COMMANDS` or `POSTBOOT_COMMANDS` environment variables to point to the absolute path of your custom boot command file, or you can just copy a custom file to the expected path (default paths are `$CONFIG_DIR/post-boot-commands.asadmin` and `$CONFIG_DIR/pre-boot-commands.asadmin`).
 
 For example, the following command will execute commands defined in the `/local/path/with/boot/file` directory mounted as a volume:
 
 ....
-docker run -p 8080:8080 -v /local/path/with/boot/file:/config -e POSTBOOT_COMMANDS=/config/post-boot-commands.asadmin payara/server-full
+docker run -p 8080:8080 -v /local/path/with/boot/file:/config -e POSTBOOT_COMMANDS=/config/post-boot-commands.asadmin payara/server-full:{currentVersion}
 ....
 
 Alternatively, the following Dockerfile will build an image which will execute the commands in the `post-boot-commands.asadmin` file:
 
 ....
-FROM payara/server-full
+FROM payara/server-full:{currentVersion}
 
 COPY post-boot-commands.asadmin $POSTBOOT_COMMANDS
 ....
 
-==== Execution of custom scripts before server startup
+==== *Execution of custom scripts before server startup*
 
 In cases this is not sufficient, you can add your own init scripts to the `${SCRIPT_DIR}`. You need to follow the naming convention: `init_<num>_<text>.sh`, where `<num>` gives you a simple option to run scripts in order. Be aware that the default deploy commands script is using this, too.
 
@@ -117,7 +150,7 @@ If you do not want to create a sub-image, you can also mount a volume to `/opt/p
 
 *Please note:* you can combine both approaches, but please keep in mind that scripts from `init.d` will run _after_ those from subimages!
 
-=== The default Docker entry point
+=== *The default Docker entry point*
 
 The default entry point is https://github.com/krallin/tini[tini], as the JVM should not run as PID 1. The default `CMD` argument for `tini` runs the `bin/entrypoint.sh` script in _exec_ mode, which in turn runs the following:
 
@@ -125,19 +158,17 @@ The default entry point is https://github.com/krallin/tini[tini], as the JVM sho
 * `${SCRIPT_DIR}/init_*.sh` scripts that you may provide for custom use as waiting or initializing during startup, *before* Glassfish kicks in.
 * `${SCRIPT_DIR}/startInForeground.sh`. This script starts the server in the foreground, in a manner that allows the Payara instance to be controlled by the docker host. The server will run the pre boot commands found in the file at `$PREBOOT_COMMANDS`, as well as the post boot commands found in the file at `$POSTBOOT_COMMANDS`.
 
-==== Testing, browsing and configuring a container instance
+==== *Testing, browsing and configuring a container instance*
 
-For testing or other purposes, you can override the default entrypoint. For example, the following command will start the container at a bash prompt, without starting Payara server. It allows you to browse the image and configure the Payara Server instance as you like:
+For testing or other purposes, you can override the default entrypoint. For example, the following command will start the container at a bash prompt, without starting Payara Server. It allows you to browse the image and configure the Payara Server instance as you like:
 
 ....
-docker run -p 8080:8080 -it payara/server-full bash
+docker run -p 8080:8080 -it payara/server-full:{currentVersion} bash
 ....
 
 == Details
 
-Payara Server installation is located in the `/opt/payara` directory. This directory is the default working directory of the docker image. The directory name is deliberately free of any versioning so that any scripts written to work with one version can be seamlessly migrated to the latest docker image.
+Payara Server installation is located in the `/opt/payara/appserver` directory. The  `/opt/payara/` directory is the default working directory of the docker image. The directory name is deliberately free of any versioning so that any scripts written to work with one version can be seamlessly migrated to the latest docker image.
 
-* Full and Web editions are derived from the OpenJDK 8 images with a Debian Jessie base
-* Micro editions are built on OpenJDK 8 images with an Alpine Linux base to keep image size as small as possible.
 
 

--- a/docs/modules/ROOT/pages/documentation/ecosystem/docker-server-usage.adoc
+++ b/docs/modules/ROOT/pages/documentation/ecosystem/docker-server-usage.adoc
@@ -103,7 +103,6 @@ The following environment variables are available to configure Payara Server to 
 * `MEM_XSS` - Defines the value of the Stack size, used in the JVM parameter `-Xss`. The default value is _512k_.
 * `DEPLOY_PROPS` - Specifies a list of properties to be passed with the deploy commands generated in the `generate_deploy_commands.sh` script, For example `'--properties=implicitCdiEnabled=false'`.
 * `PREBOOT_COMMANDS` - The name of the file containing pre boot commands for the Payara Server instance.
-* `ADMIN_PASSWORD` - The password used for accessing the server in combination with user name defined in  `ADMIN_USER`. By default this is `admin`.
 * `PAYARA_ARGS` - additional arguments to the `start-domain` command that starts the server. Use this only if it’s not enough to specify the configuration using the `POSTBOOT_COMMANDS` or `PREBOOT_COMMANDS` file
 * `JVM_ARGS` - Specifies a list of JVM arguments which will be passed to Payara in the `startInForeground.sh` script.
 
@@ -119,6 +118,7 @@ The following environment variables shouldn’t be changed, but may be helpful i
 |`DEPLOY_DIR` |`/opt/payara/deployments` |The directory where applications are searched for in `generate_deploy_commands.sh` script.
 |`PASSWORD_FILE` |`/opt/payara/passwordFile` |The location of the password file for asadmin. This can be passed to asadmin using the `--passwordfile` parameter.
 |`ADMIN_USER` |`admin` |The user name for accessing the server with secure administration.
+|`ADMIN_PASSWORD` |`admin` | The password used for accessing the server in combination with user name defined in  `ADMIN_USER`. By default this is `admin`. Can only be set when the basic image is created.
 |`DOMAIN_NAME` |`production` | The name of the domain running within the container. 
 |`AS_ADMIN_MASTERPASSWORD` |`changit` |  The master password to pass to Payara Server. This is overriden if one is specified in the `$PASSWORD_FILE`.
 |===


### PR DESCRIPTION
1: Transfer of the readme files of the archived Github repo containing Docker Image usage.

This is the basis to start improved and updated Payara Docker Image usage.