### PR TITLE
Add documentation preview scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ package-lock.json
 .project
 migrate-antora.sh
 
+# Antora local build
+build/

--- a/local-playbook.yml
+++ b/local-playbook.yml
@@ -1,0 +1,19 @@
+site:
+    title: Payara Documentation Preview
+    start_page: docs::README.adoc
+content:
+    sources:
+    - url: ./
+      start_path: docs
+      branches: HEAD
+asciidoc:
+    attributes:
+        attribute-missing: 'skip'
+ui:
+    bundle:
+        url: https://github.com/payara/antora-ui-default/raw/master/build/ui-bundle.zip
+        snapshot: true
+runtime:
+    fetch: true
+output:
+    dir: ./build/html

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "payara-documentation-preview",
+  "version": "1.0.0",
+  "description": "A collection of NPM scripts for running the Payara Documentation Preview",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "start": "npm run watch & npm run serve",
+    "serve": "http-server build/html -c-1 -p 5000",
+    "watch": "nodemon --watch docs -e adoc --exec antora local-playbook.yml"
+  },
+  "devDependencies": {
+    "@antora/cli": "^2.3.4",
+    "@antora/site-generator-default": "^2.3.4",
+    "http-server": "^0.12.3",
+    "nodemon": "^2.0.5"
+  }
+}


### PR DESCRIPTION
NPM scripts added to run the documentation locally for review.

Run `npm start` to preview the docs locally. The docs will update when modified (although it takes a while, antora doesn't have hot reload by default).

Signed-off-by: Matthew Gill <matthew.gill@live.co.uk>