### PR TITLE
Remove claim of supporting OpenJ9

### DIFF
--- a/docs/modules/ROOT/pages/general-info/supported-platforms.adoc
+++ b/docs/modules/ROOT/pages/general-info/supported-platforms.adoc
@@ -6,13 +6,12 @@ details the JVMs currently supported by the Payara Platform Community (both Paya
 
 == Supported Java Virtual Machines
 
-The Payara Platform currently runs the following Java Virtual Machines:
+The Payara Platform currently runs on the following Java Virtual Machines:
 
 * Azul Zulu JDK: 8 (u162+), 11 (11.0.5u10+)
 * Oracle JDK: 8 (u162+), 11 (11.0.5+)
 * Amazon Corretto: 8, 11 (11.0.5+)
 * Adopt Open JDK: 8, 11 (11.0.5+)
-* Adopt Open JDK with Eclipse Open J9: 8, 11 (11.0.5+)
 * Any other JVM based on OpenJDK 8u162+ or 11.0.5+
 
 The Payara Platform runs on the `x64` and `arm64` variants of the above JVMs.


### PR DESCRIPTION
At least until we resolve the blocking issues with OpenJ9.

For more details, see QACI-346.