### PR TITLE
FISH-105 Document change in migrate timers

### DIFF
--- a/docs/modules/ROOT/pages/documentation/payara-server/ejb/persistent-timers.adoc
+++ b/docs/modules/ROOT/pages/documentation/payara-server/ejb/persistent-timers.adoc
@@ -62,3 +62,5 @@ asadmin> migrate-timers --target server1 server2
 ----
 
 Where `server1` is the active instance to migrate timers to and `server2` is the failed instance.
+
+Since Payara Server 5.2020.1, the `migrate-timers` command can also be used to migrate timers from a live instance.

--- a/docs/modules/ROOT/pages/documentation/payara-server/ejb/persistent-timers.adoc
+++ b/docs/modules/ROOT/pages/documentation/payara-server/ejb/persistent-timers.adoc
@@ -69,6 +69,6 @@ Where `server1` is the active instance to migrate timers to and `server2` is the
 _Since Payara Server 5.2020.1_
 
 The `migrate-timers` command can also be used to migrate timers that are scheduled to expire on a live instance.
-The user previously had little control over the instance on a deployment group that a timer would execute on, with the
+Users previously had little control over the instance on a deployment group that a timer would execute on, with the
 only way to force migration to another instance being to stop the instance they were currently executing on. This change
 allows a user to pre-emptively move their timers around without having to resort to failover mechanics.

--- a/docs/modules/ROOT/pages/documentation/payara-server/ejb/persistent-timers.adoc
+++ b/docs/modules/ROOT/pages/documentation/payara-server/ejb/persistent-timers.adoc
@@ -63,4 +63,12 @@ asadmin> migrate-timers --target server1 server2
 
 Where `server1` is the active instance to migrate timers to and `server2` is the failed instance.
 
-Since Payara Server 5.2020.1, the `migrate-timers` command can also be used to migrate timers from a live instance.
+[[migration-live-instance]]
+=== Migration from Live Instances
+
+_Since Payara Server 5.2020.1_
+
+The `migrate-timers` command can also be used to migrate timers that are scheduled to expire on a live instance.
+The user previously had little control over the instance on a deployment group that a timer would execute on, with the
+only way to force migration to another instance being to stop the instance they were currently executing on. This change
+allows a user to pre-emptively move their timers around without having to resort to failover mechanics.


### PR DESCRIPTION
Timers can now be migrated from live instances.