### PR TITLE
SERV-586 change display version to latest for 'master'

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,6 +1,7 @@
 name: docs
 title: Payara Platform
 version: master
+display_version: 'Latest'
 start_page: ROOT:README.adoc
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
The temporary solution while we wait for Antora 3.0, which will allow us to substitute the 'latest' tag with a version in the URL, this mimicks the behaviour but will give access to unreleased documentation. 

master will have to be added to the list of branches in the payara-documentation-playbook, also when branching off a new version from the master branch, the display_version will have to be removed before building and publishing.

Making PR to community first for testing.

PR to add master to avaliable branches: https://github.com/payara/payara-documentation-playbook/pull/1