### PR TITLE
Update download link to maven central

### DIFF
--- a/docs/modules/ROOT/pages/jakartaee-certification/6.2021.1.Alpha1/tck-results-full-6.2021.1.Alpha1.adoc
+++ b/docs/modules/ROOT/pages/jakartaee-certification/6.2021.1.Alpha1/tck-results-full-6.2021.1.Alpha1.adoc
@@ -15,7 +15,7 @@ following is a summary of the TCK results for releases of Jakarta EE Platform, F
 |
 {empty} +
 {empty} +
-https://www.payara.fish/downloads/payara-platform-community-edition[Payara Server 6.2021.1.Alpha1]
+https://search.maven.org/artifact/fish.payara.distributions/payara/6.2021.1.Alpha1/zip[Payara Server 6.2021.1.Alpha1]
 |===
 
 - Specification Name, Version and download URL:


### PR DESCRIPTION
Download URL is pointing to website, it should be pointing to maven central as there is no download link for 6 on the website.