### PR TITLE
Update jcache javadoc links

### DIFF
--- a/docs/modules/ROOT/pages/documentation/payara-server/jcache/jcache-annotations.adoc
+++ b/docs/modules/ROOT/pages/documentation/payara-server/jcache/jcache-annotations.adoc
@@ -6,23 +6,23 @@ set of JCache annotations to be used.
 
 The JCache annotations are as follows:
 
-https://ignite.incubator.apache.org/jcache/1.0.0/javadoc/javax/cache/annotation/CachePut.html[@CachePut]::
+https://ignite.apache.org/jcache/1.0.0/javadoc/javax/cache/annotation/CachePut.html[@CachePut]::
 Puts the specified key and value in the cache.
 
-https://ignite.incubator.apache.org/jcache/1.0.0/javadoc/javax/cache/annotation/CacheRemove.html[@CacheRemove]::
+https://ignite.apache.org/jcache/1.0.0/javadoc/javax/cache/annotation/CacheRemove.html[@CacheRemove]::
 Removes the specified key and value from the cache.
 
-https://ignite.incubator.apache.org/jcache/1.0.0/javadoc/javax/cache/annotation/CacheResult.html[@CacheResult]::
+https://ignite.apache.org/jcache/1.0.0/javadoc/javax/cache/annotation/CacheResult.html[@CacheResult]::
 Retrieves the value associated with the specified key.
 
-https://ignite.incubator.apache.org/jcache/1.0.0/javadoc/javax/cache/annotation/CacheRemoveAll.html[@CacheRemoveAll]::
+https://ignite.apache.org/jcache/1.0.0/javadoc/javax/cache/annotation/CacheRemoveAll.html[@CacheRemoveAll]::
 Removes all keys and values from the cache.
 
-https://ignite.incubator.apache.org/jcache/1.0.0/javadoc/javax/cache/annotation/CacheDefaults.html[@CacheDefaults]::
+https://ignite.apache.org/jcache/1.0.0/javadoc/javax/cache/annotation/CacheDefaults.html[@CacheDefaults]::
 Allows the configuration of defaults for `CacheResult`, `CachePut`, `CacheRemove`, and `CacheRemoveAll` at the class level.
 
-https://ignite.incubator.apache.org/jcache/1.0.0/javadoc/javax/cache/annotation/CacheKey.html[@CacheKey]::
+https://ignite.apache.org/jcache/1.0.0/javadoc/javax/cache/annotation/CacheKey.html[@CacheKey]::
 Marks a method parameter as the key of a cache.
 
-https://ignite.incubator.apache.org/jcache/1.0.0/javadoc/javax/cache/annotation/CacheValue.html[@CacheValue]::
+https://ignite.apache.org/jcache/1.0.0/javadoc/javax/cache/annotation/CacheValue.html[@CacheValue]::
 Marks a method parameter as the value of a cache key.

--- a/docs/modules/ROOT/pages/documentation/payara-server/request-tracing-service/tracing-remote-ejbs.adoc
+++ b/docs/modules/ROOT/pages/documentation/payara-server/request-tracing-service/tracing-remote-ejbs.adoc
@@ -29,7 +29,7 @@ contextProperties.setProperty(Context.INITIAL_CONTEXT_FACTORY, "com.sun.enterpri
 
 try {
     Context context = new InitialContext(contextProperties);
-    EjbRemote ejb = (EjbRemote) context.lookup(java:global/myRemoteEjb/Ejb);
+    EjbRemote ejb = (EjbRemote) context.lookup("java:global/myRemoteEjb/Ejb");
 } catch (NamingException ne) {
     logger.warning("Failed performing lookup:\n" + ne.getMessage());
 }
@@ -65,7 +65,7 @@ contextProperties.setProperty(Context.INITIAL_CONTEXT_FACTORY, "com.sun.enterpri
 
 try {
     Context context = new InitialContext(contextProperties);
-    EjbRemote ejb = (EjbRemote) context.lookup(java:global/myRemoteEjb/Ejb);
+    EjbRemote ejb = (EjbRemote) context.lookup("java:global/myRemoteEjb/Ejb");
 
     Tracer tracer = GlobalTracer.get();
 } catch (NamingException ne) {
@@ -108,7 +108,7 @@ contextProperties.setProperty(Context.INITIAL_CONTEXT_FACTORY, "com.sun.enterpri
 
 try {
     Context context = new InitialContext(contextProperties);
-    EjbRemote ejb = (EjbRemote) context.lookup(java:global/myRemoteEjb/Ejb);
+    EjbRemote ejb = (EjbRemote) context.lookup("java:global/myRemoteEjb/Ejb");
 
     Tracer tracer = GlobalTracer.get();
 


### PR DESCRIPTION
Current links lead to ignite project, but uses the old incubator address, which has to redirect. This update links directly to the current address.