### PR TITLE
Added missing release notes for 5.2021.6

### DIFF
--- a/docs/modules/ROOT/pages/release-notes/release-notes-2020-2.adoc
+++ b/docs/modules/ROOT/pages/release-notes/release-notes-2020-2.adoc
@@ -43,6 +43,7 @@ deployment failure when to use @RolesPermitted in Faces backing bean
 Hazelcast being started twice to improve Micro boot times
 * [https://github.com/payara/Payara/pull/4594[CUSTCOM-238]] - Support
 JSP on Payara Micro Docker
+* [https://github.com/payara/Payara/pull/4604[FISH-1332]] - Allow Executing 'preboot' and 'postboot' Commands over Payara Micro API
 
 == Bug Fixes
 

--- a/docs/modules/ROOT/pages/release-notes/release-notes-2021-6.adoc
+++ b/docs/modules/ROOT/pages/release-notes/release-notes-2021-6.adoc
@@ -1,0 +1,29 @@
+= Release Notes - Payara Platform Community 5.2021.6
+
+== Supported APIs and Applications
+
+* Jakarta EE 8
+* Java EE 8 Applications
+* Jakarta EE 9
+* MicroProfile 4.1
+
+=== New Features
+* [https://github.com/payara/Payara/pull/5303[FISH-1372]] - MicroProfile Health 3.1
+* [https://github.com/payara/Payara/pull/5338[FISH-385]] - OpenID Connect: Per-session configuration and multitenancy
+* [https://github.com/payara/ecosystem-security-connectors/pull/80[FISH-384]] - Support Bearer authentication for OpenID authentication mechanism
+
+=== Bug Fixes
+* [https://github.com/payara/Payara/pull/5362[FISH-5654]] - NullPointerException when setting server log format to JSON
+* [https://github.com/payara/Payara/pull/5343[FISH-1530]] - Fix OpenAPI TCK Tag Collection Test
+* [https://github.com/payara/Payara/pull/5336[FISH-1521]] - Fix Incorrect Group/Role Mapping in OIDC Provider
+* [https://github.com/payara/Payara/pull/5372[FISH-1520]] - Fix MicroProfile JWT-Auth TCK Failures
+* [https://github.com/payara/Payara/pull/5359[FISH-1345]] - EE9 Transformer does not recognize the CDI 3.0 namespace in beans.xml; interceptor ignored.
+* [https://github.com/payara/Payara/pull/5342[FISH-1312]] - MP OpenAPI schema property hidden is ignored
+* [https://github.com/payara/Payara/pull/5359[FISH-1278]] - Jakarta namespace transformation ignored for JSP packaged in the EAR
+
+=== Component Upgrades
+* [https://github.com/payara/Payara/pull/5373[FISH-786]] - Integrate Security Connector with the Payara Platform
+
+=== Security Fixes
+* [https://github.com/payara/Payara/pull/5349[FISH-5545]] - Upgrade jackson-databind to 2.12.4
+* [https://github.com/payara/Payara/pull/5344[FISH-5544]] - Upgrade json-smart dependency to 2.4.7


### PR DESCRIPTION
which mysteriously disappeared since the previous release

Plus added FISH-1332 to 5.2020.2 release notes which was missed when it was fixed.