### PR TITLE
FISH-5769 Default CertificateAuthenticationMechanism is Incompatible With '@CertificateAuthenticationMechanismDefinition'

### DIFF
--- a/docs/modules/ROOT/pages/documentation/payara-server/public-api/realm-identitystores/certificate-identity-store-definition.adoc
+++ b/docs/modules/ROOT/pages/documentation/payara-server/public-api/realm-identitystores/certificate-identity-store-definition.adoc
@@ -30,6 +30,15 @@ public class MyRestApp extends Application {
 }
 ----
 
+NOTE: Jakarta Security 2.0 did not implement CLIENT-CERT authentication. If you are using a self-signed certificate you still need to specify the CLIENT-CERT auth-method in your web.xml
+
+[source, xml]
+----
+<login-config>
+    <auth-method>CLIENT-CERT</auth-method>
+</login-config>
+----
+
 [[configuration]]
 == Configuration
 


### PR DESCRIPTION
Documented limitation for clarity.

Community PR: https://github.com/payara/Payara/pull/5438