### PR TITLE
FISH-6242 Document Update Docker Images for ZLib CVE-2018-25032

### DIFF
--- a/docs/modules/ROOT/pages/security/security-fix-list.adoc
+++ b/docs/modules/ROOT/pages/security/security-fix-list.adoc
@@ -9,6 +9,8 @@ can or have impacted Payara Server across releases:
 |=======================================================================
 |ID |CVSS v3.0 Base Score |Status |Summary |Release |Pull Requests |Observations
 
+|https://nvd.nist.gov/vuln/detail/CVE-2018-25032[CVE-2018-25032] | 7.5 | FIXED | ZLib allows memory corruption when deflating (i.e. when compressing) if the input has many distant matches. | 5.2022.2 | https://github.com/payara/Payara/pull/5638 | Fixed by upgrading to Azul JDK version using ZLib 1.2.12 in Payara Docker Images.
+
 |https://nvd.nist.gov/vuln/detail/CVE-2021-42392[CVE-2021-42392] | N/A | N/A | Unauthenticated RCE in H2 Database Console |  |  | Doesn't affect Payara Platform. The Payara Platform doesn't launch the H2 Database Console and doesn't make it available in any way.
 
 | https://nvd.nist.gov/vuln/detail/CVE-2021-40690/[CVE-2021-40690] | 7.5 | FIXED | The "secureValidation" property is not passed correctly when creating a KeyInfo from a KeyInfoReference element, allowing abuse of an XPath Transform to extract any local .xml files in a RetrievalMethod element. | 5.2021.10 | https://github.com/payara/Payara/pull/5505[#5505] | Fixed by upgrading Apache Santuario to 2.2.3


### PR DESCRIPTION
Title. In reference to https://nvd.nist.gov/vuln/detail/CVE-2018-25032